### PR TITLE
Fixup gemspec when loading breezy, require 'breezy_template' in a gem…

### DIFF
--- a/breezy.gemspec
+++ b/breezy.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.license  = 'MIT'
   s.homepage = 'https://github.com/jho406/breezy/'
   s.summary  = 'Turbolinks for react and rails'
-  s.files    = Dir["lib/assets/javascripts/*.coffee", "lib/breezy.rb", "lib/breezy/*.rb", "README.md", "MIT-LICENSE", "test/*"]
+  s.files    = Dir["lib/assets/javascripts/*.coffee", "lib/breezy.rb", "lib/breezy_template.rb", "lib/breezy/*.rb", "README.md", "MIT-LICENSE", "test/*"]
   s.test_files = Dir["test/*"]
 
   s.add_dependency 'coffee-rails', '~> 4.0'


### PR DESCRIPTION
require 'breezy_template' in a gem will trigger error, because lib/breezy/*.rb does not include breezy_template for some reason, you can also use `git ls-file lib/` to list all files in here, which is more reliable than Dir